### PR TITLE
Add CI workflow to test bootstrap.sh

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,22 @@
+name: Bootstrap
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: dotfiles
+
+      - name: Move to ~/dotfiles
+        run: mv dotfiles ~/dotfiles
+
+      - name: Run bootstrap
+        run: sudo -E ~/dotfiles/bootstrap.sh


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that checks out the repo to `~/dotfiles` and runs `bootstrap.sh`
- Runs on pushes and PRs to master

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)