### PR TITLE
Add Amazon Linux bootstrap workflow job

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -39,20 +39,22 @@ jobs:
     # fails before any install step can run. Bootstrap this job manually.
     steps:
       - name: Install prerequisites
-        run: dnf install -y git tar gzip sudo shadow-utils
+        run: |
+          dnf groupinstall -y "Development Tools"
+          dnf install -y curl file git gzip procps-ng sudo shadow-utils tar
 
-      - name: Create bootstrap user
-        run: useradd --create-home bootstrap
+      - name: Create linuxbrew user
+        run: useradd --create-home --home-dir /home/linuxbrew linuxbrew
 
       - name: Clone repository
         run: |
-          git clone https://github.com/${{ github.repository }} /home/bootstrap/dotfiles
-          chown -R bootstrap:bootstrap /home/bootstrap/dotfiles
+          git clone https://github.com/${{ github.repository }} /home/linuxbrew/dotfiles
+          chown -R linuxbrew:linuxbrew /home/linuxbrew/dotfiles
 
       - name: Checkout workflow revision
         run: |
-          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles fetch --no-tags origin ${{ github.sha }}
-          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles checkout --detach ${{ github.sha }}
+          sudo -Hu linuxbrew git -C /home/linuxbrew/dotfiles fetch --no-tags origin ${{ github.sha }}
+          sudo -Hu linuxbrew git -C /home/linuxbrew/dotfiles checkout --detach ${{ github.sha }}
 
       - name: Run bootstrap
-        run: SUDO_USER=bootstrap sudo -E /home/bootstrap/dotfiles/bootstrap.sh
+        run: SUDO_USER=linuxbrew sudo -E /home/linuxbrew/dotfiles/bootstrap.sh

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -57,4 +57,4 @@ jobs:
           sudo -Hu linuxbrew git -C /home/linuxbrew/dotfiles checkout --detach ${{ github.sha }}
 
       - name: Run bootstrap
-        run: SUDO_USER=linuxbrew sudo -E /home/linuxbrew/dotfiles/bootstrap.sh
+        run: SUDO_USER=linuxbrew /home/linuxbrew/dotfiles/bootstrap.sh

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,6 +10,18 @@ concurrency:
   group: bootstrap-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+bootstrap_steps: &bootstrap_steps
+  - name: Checkout
+    uses: actions/checkout@v6
+    with:
+      path: dotfiles
+
+  - name: Move to ~/dotfiles
+    run: mv dotfiles ~/dotfiles
+
+  - name: Run bootstrap
+    run: sudo -E ~/dotfiles/bootstrap.sh
+
 jobs:
   bootstrap:
     strategy:
@@ -18,31 +30,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: dotfiles
-
-      - name: Move to ~/dotfiles
-        run: mv dotfiles ~/dotfiles
-
-      - name: Run bootstrap
-        run: sudo -E ~/dotfiles/bootstrap.sh
+    steps: *bootstrap_steps
 
   bootstrap-amazon-linux:
     runs-on: ubuntu-latest
     container:
       image: amazonlinux:2023
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          path: dotfiles
-
-      - name: Move to ~/dotfiles
-        run: mv dotfiles ~/dotfiles
-
-      - name: Run bootstrap
-        run: sudo -E ~/dotfiles/bootstrap.sh
+    steps: *bootstrap_steps

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -39,16 +39,20 @@ jobs:
     # fails before any install step can run. Bootstrap this job manually.
     steps:
       - name: Install prerequisites
-        run: dnf install -y git tar gzip sudo
+        run: dnf install -y git tar gzip sudo shadow-utils
+
+      - name: Create bootstrap user
+        run: useradd --create-home bootstrap
 
       - name: Clone repository
-        run: git clone https://github.com/${{ github.repository }} ~/dotfiles
+        run: |
+          git clone https://github.com/${{ github.repository }} /home/bootstrap/dotfiles
+          chown -R bootstrap:bootstrap /home/bootstrap/dotfiles
 
       - name: Checkout workflow revision
         run: |
-          cd ~/dotfiles
-          git fetch --no-tags origin ${{ github.sha }}
-          git checkout --detach ${{ github.sha }}
+          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles fetch --no-tags origin ${{ github.sha }}
+          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles checkout --detach ${{ github.sha }}
 
       - name: Run bootstrap
-        run: SUDO_USER=root sudo -E ~/dotfiles/bootstrap.sh
+        run: SUDO_USER=bootstrap sudo -E /home/bootstrap/dotfiles/bootstrap.sh

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -37,4 +37,20 @@ jobs:
     container:
       image: amazonlinux:2023
 
-    steps: *bootstrap_steps
+    # The stock AL2023 container does not include tar, so actions/checkout
+    # fails before any install step can run. Bootstrap this job manually.
+    steps:
+      - name: Install prerequisites
+        run: dnf install -y git tar gzip sudo
+
+      - name: Clone repository
+        run: git clone https://github.com/${{ github.repository }} ~/dotfiles
+
+      - name: Checkout workflow revision
+        run: |
+          cd ~/dotfiles
+          git fetch --no-tags origin ${{ github.sha }}
+          git checkout --detach ${{ github.sha }}
+
+      - name: Run bootstrap
+        run: SUDO_USER=root sudo -E ~/dotfiles/bootstrap.sh

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -14,7 +14,7 @@ jobs:
   bootstrap:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, amazonlinux-latest]
 
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -43,18 +43,24 @@ jobs:
           dnf groupinstall -y "Development Tools"
           dnf install -y file git gzip procps-ng sudo shadow-utils tar
 
-      - name: Create linuxbrew user
-        run: useradd --create-home --home-dir /home/linuxbrew linuxbrew
+      - name: Create bootstrap user
+        run: |
+          useradd --create-home --home-dir /home/bootstrap bootstrap
+          echo 'bootstrap ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/bootstrap
+          chmod 440 /etc/sudoers.d/bootstrap
 
       - name: Clone repository
         run: |
-          git clone https://github.com/${{ github.repository }} /home/linuxbrew/dotfiles
-          chown -R linuxbrew:linuxbrew /home/linuxbrew/dotfiles
+          git clone https://github.com/${{ github.repository }} /home/bootstrap/dotfiles
+          chown -R bootstrap:bootstrap /home/bootstrap/dotfiles
 
       - name: Checkout workflow revision
         run: |
-          sudo -Hu linuxbrew git -C /home/linuxbrew/dotfiles fetch --no-tags origin ${{ github.sha }}
-          sudo -Hu linuxbrew git -C /home/linuxbrew/dotfiles checkout --detach ${{ github.sha }}
+          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles fetch --no-tags origin ${{ github.sha }}
+          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles checkout --detach ${{ github.sha }}
 
       - name: Run bootstrap
-        run: SUDO_USER=linuxbrew /home/linuxbrew/dotfiles/bootstrap.sh
+        run: |
+          su - bootstrap <<'EOF'
+          sudo /home/bootstrap/dotfiles/bootstrap.sh
+          EOF

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install prerequisites
         run: |
           dnf groupinstall -y "Development Tools"
-          dnf install -y curl file git gzip procps-ng sudo shadow-utils tar
+          dnf install -y file git gzip procps-ng sudo shadow-utils tar
 
       - name: Create linuxbrew user
         run: useradd --create-home --home-dir /home/linuxbrew linuxbrew

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -14,10 +14,27 @@ jobs:
   bootstrap:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, amazonlinux-latest]
+        os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
     
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: dotfiles
+
+      - name: Move to ~/dotfiles
+        run: mv dotfiles ~/dotfiles
+
+      - name: Run bootstrap
+        run: sudo -E ~/dotfiles/bootstrap.sh
+
+  bootstrap-amazon-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: amazonlinux:2023
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,18 +10,6 @@ concurrency:
   group: bootstrap-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-bootstrap_steps: &bootstrap_steps
-  - name: Checkout
-    uses: actions/checkout@v6
-    with:
-      path: dotfiles
-
-  - name: Move to ~/dotfiles
-    run: mv dotfiles ~/dotfiles
-
-  - name: Run bootstrap
-    run: sudo -E ~/dotfiles/bootstrap.sh
-
 jobs:
   bootstrap:
     strategy:
@@ -29,8 +17,18 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
-    
-    steps: *bootstrap_steps
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: dotfiles
+
+      - name: Move to ~/dotfiles
+        run: mv dotfiles ~/dotfiles
+
+      - name: Run bootstrap
+        run: sudo -E ~/dotfiles/bootstrap.sh
 
   bootstrap-amazon-linux:
     runs-on: ubuntu-latest

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,14 +13,23 @@ have_cmd() {
   command -v "$1" >/dev/null 2>&1
 }
 
-user_brew_bin() {
+user_brew_path() {
   local resolved_home="${user_home:-}"
+  local user_prefix=
+  local shared_prefix="/home/linuxbrew/.linuxbrew/bin"
 
   if [ -z "$resolved_home" ]; then
     resolved_home=$(sudo -Hiu "$SUDO_USER" sh -lc 'printf %s "$HOME"')
   fi
 
-  printf '%s/.linuxbrew/bin\n' "$resolved_home"
+  user_prefix="${resolved_home}/.linuxbrew/bin"
+
+  if [ -x "${shared_prefix}/brew" ]; then
+    printf '/opt/homebrew/bin:%s:%s:/usr/local/bin:/usr/bin:/bin\n' "$shared_prefix" "$user_prefix"
+    return
+  fi
+
+  printf '/opt/homebrew/bin:%s:%s:/usr/local/bin:/usr/bin:/bin\n' "$user_prefix" "$shared_prefix"
 }
 
 run_as_user() {
@@ -28,12 +37,12 @@ run_as_user() {
 }
 
 have_user_cmd() {
-  run_as_user env PATH="/opt/homebrew/bin:$(user_brew_bin):/usr/local/bin:/usr/bin:/bin" \
+  run_as_user env PATH="$(user_brew_path)" \
     sh -lc 'command -v "$1" >/dev/null 2>&1' sh "$1"
 }
 
 brew_as_user() {
-  run_as_user env PATH="/opt/homebrew/bin:$(user_brew_bin):/usr/local/bin:/usr/bin:/bin" brew "$@"
+  run_as_user env PATH="$(user_brew_path)" brew "$@"
 }
 
 install_with_apt() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,7 @@ script_dir=
 target=
 user_home=
 os_name=
+linux_package_manager=
 
 have_cmd() {
   command -v "$1" >/dev/null 2>&1
@@ -17,12 +18,12 @@ run_as_user() {
 }
 
 have_user_cmd() {
-  run_as_user env PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+  run_as_user env PATH="/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin" \
     sh -lc 'command -v "$1" >/dev/null 2>&1' sh "$1"
 }
 
 brew_as_user() {
-  run_as_user env PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" brew "$@"
+  run_as_user env PATH="/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin" brew "$@"
 }
 
 install_with_apt() {
@@ -40,12 +41,20 @@ install_with_brew() {
 
 install_homebrew_if_needed() {
   if ! have_user_cmd brew; then
-    run_as_user /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    run_as_user env NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 }
 
 resolve_os() {
   os_name="$(uname -s)"
+
+  if [ "$os_name" = "Linux" ]; then
+    if have_cmd apt-get; then
+      linux_package_manager=apt
+    else
+      linux_package_manager=brew
+    fi
+  fi
 }
 
 resolve_script_dir() {
@@ -59,7 +68,17 @@ managed_cmd_exists() {
 
   case "$os_name" in
     Linux)
-      [ -n "$linux_check_cmd" ] && have_cmd "$linux_check_cmd"
+      case "$linux_package_manager" in
+        apt)
+          [ -n "$linux_check_cmd" ] && have_cmd "$linux_check_cmd"
+          ;;
+        brew)
+          [ -n "$darwin_check_cmd" ] && have_user_cmd "$darwin_check_cmd"
+          ;;
+        *)
+          return 1
+          ;;
+      esac
       ;;
     Darwin)
       [ -n "$darwin_check_cmd" ] && have_user_cmd "$darwin_check_cmd"
@@ -76,7 +95,17 @@ package_spec_for_current_os() {
 
   case "$os_name" in
     Linux)
-      printf '%s\n' "$apt_packages"
+      case "$linux_package_manager" in
+        apt)
+          printf '%s\n' "$apt_packages"
+          ;;
+        brew)
+          printf '%s\n' "$brew_packages"
+          ;;
+        *)
+          return 1
+          ;;
+      esac
       ;;
     Darwin)
       printf '%s\n' "$brew_packages"
@@ -102,9 +131,23 @@ resolve_target() {
 ensure_bootstrap_deps() {
   case "$os_name" in
     Linux)
-      if ! have_cmd git; then
-        install_with_apt git
-      fi
+      case "$linux_package_manager" in
+        apt)
+          if ! have_cmd git; then
+            install_with_apt git
+          fi
+          ;;
+        brew)
+          install_homebrew_if_needed
+          if ! have_user_cmd git; then
+            install_with_brew git
+          fi
+          ;;
+        *)
+          echo "Unsupported Linux package manager" >&2
+          exit 1
+          ;;
+      esac
       ;;
     Darwin)
       install_homebrew_if_needed
@@ -145,11 +188,11 @@ ensure_packages() {
     fi
 
     read -r -a package_args <<<"$package_spec"
-    case "$os_name" in
-      Linux)
+    case "$os_name:$linux_package_manager" in
+      Linux:apt)
         install_with_apt "${package_args[@]}" </dev/null
         ;;
-      Darwin)
+      Linux:brew|Darwin:*)
         install_with_brew "${package_args[@]}" </dev/null
         ;;
     esac

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,17 +13,27 @@ have_cmd() {
   command -v "$1" >/dev/null 2>&1
 }
 
+user_brew_bin() {
+  local resolved_home="${user_home:-}"
+
+  if [ -z "$resolved_home" ]; then
+    resolved_home=$(sudo -Hiu "$SUDO_USER" sh -lc 'printf %s "$HOME"')
+  fi
+
+  printf '%s/.linuxbrew/bin\n' "$resolved_home"
+}
+
 run_as_user() {
   sudo -Hu "$SUDO_USER" -- "$@"
 }
 
 have_user_cmd() {
-  run_as_user env PATH="/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin" \
+  run_as_user env PATH="/opt/homebrew/bin:$(user_brew_bin):/usr/local/bin:/usr/bin:/bin" \
     sh -lc 'command -v "$1" >/dev/null 2>&1' sh "$1"
 }
 
 brew_as_user() {
-  run_as_user env PATH="/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin" brew "$@"
+  run_as_user env PATH="/opt/homebrew/bin:$(user_brew_bin):/usr/local/bin:/usr/bin:/bin" brew "$@"
 }
 
 install_with_apt() {


### PR DESCRIPTION
## Summary
- keep the existing hosted runner matrix for Ubuntu and macOS
- add an Amazon Linux 2023 bootstrap job that runs in a container on `ubuntu-latest`
- avoid relying on a nonexistent GitHub-hosted Amazon Linux runner

## Notes
- this allows the workflow to start and execute on Amazon Linux userspace via a container-backed job
- the existing bootstrap script is unchanged