### PR TITLE
Add Amazon Linux bootstrap support

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,3 +29,38 @@ jobs:
 
       - name: Run bootstrap
         run: sudo -E ~/dotfiles/bootstrap.sh
+
+  bootstrap-amazon-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: amazonlinux:2023
+
+    # The stock AL2023 container does not include tar, so actions/checkout
+    # fails before any install step can run. Bootstrap this job manually.
+    steps:
+      - name: Install prerequisites
+        run: |
+          dnf groupinstall -y "Development Tools"
+          dnf install -y file git gzip procps-ng sudo shadow-utils tar
+
+      - name: Create bootstrap user
+        run: |
+          useradd --create-home --home-dir /home/bootstrap bootstrap
+          echo 'bootstrap ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/bootstrap
+          chmod 440 /etc/sudoers.d/bootstrap
+
+      - name: Clone repository
+        run: |
+          git clone https://github.com/${{ github.repository }} /home/bootstrap/dotfiles
+          chown -R bootstrap:bootstrap /home/bootstrap/dotfiles
+
+      - name: Checkout workflow revision
+        run: |
+          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles fetch --no-tags origin ${{ github.sha }}
+          sudo -Hu bootstrap git -C /home/bootstrap/dotfiles checkout --detach ${{ github.sha }}
+
+      - name: Run bootstrap
+        run: |
+          su - bootstrap <<'EOF'
+          sudo /home/bootstrap/dotfiles/bootstrap.sh
+          EOF

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 apt_updated=0
 package_manifest=
+pkg_manager=
 script_dir=
 target=
 user_home=
@@ -16,13 +17,15 @@ run_as_user() {
   sudo -Hu "$SUDO_USER" -- "$@"
 }
 
+brew_path="/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
 have_user_cmd() {
-  run_as_user env PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+  run_as_user env PATH="$brew_path" \
     sh -lc 'command -v "$1" >/dev/null 2>&1' sh "$1"
 }
 
 brew_as_user() {
-  run_as_user env PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" brew "$@"
+  run_as_user env PATH="$brew_path" brew "$@"
 }
 
 install_with_apt() {
@@ -40,12 +43,32 @@ install_with_brew() {
 
 install_homebrew_if_needed() {
   if ! have_user_cmd brew; then
-    run_as_user /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    run_as_user env NONINTERACTIVE=1 /bin/bash -c \
+      "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 }
 
 resolve_os() {
   os_name="$(uname -s)"
+}
+
+resolve_pkg_manager() {
+  case "$os_name" in
+    Darwin)
+      pkg_manager="brew"
+      ;;
+    Linux)
+      if have_cmd apt-get; then
+        pkg_manager="apt"
+      else
+        pkg_manager="brew"
+      fi
+      ;;
+    *)
+      echo "Unsupported OS: $os_name" >&2
+      exit 1
+      ;;
+  esac
 }
 
 resolve_script_dir() {
@@ -54,36 +77,26 @@ resolve_script_dir() {
 }
 
 managed_cmd_exists() {
-  local linux_check_cmd="$1"
-  local darwin_check_cmd="$2"
+  local apt_check_cmd="$1"
+  local brew_check_cmd="$2"
 
-  case "$os_name" in
-    Linux)
-      [ -n "$linux_check_cmd" ] && have_cmd "$linux_check_cmd"
+  case "$pkg_manager" in
+    apt)
+      [ -n "$apt_check_cmd" ] && have_cmd "$apt_check_cmd"
       ;;
-    Darwin)
-      [ -n "$darwin_check_cmd" ] && have_user_cmd "$darwin_check_cmd"
-      ;;
-    *)
-      return 1
+    brew)
+      [ -n "$brew_check_cmd" ] && have_user_cmd "$brew_check_cmd"
       ;;
   esac
 }
 
-package_spec_for_current_os() {
+package_spec() {
   local apt_packages="$1"
   local brew_packages="$2"
 
-  case "$os_name" in
-    Linux)
-      printf '%s\n' "$apt_packages"
-      ;;
-    Darwin)
-      printf '%s\n' "$brew_packages"
-      ;;
-    *)
-      return 1
-      ;;
+  case "$pkg_manager" in
+    apt)  printf '%s\n' "$apt_packages" ;;
+    brew) printf '%s\n' "$brew_packages" ;;
   esac
 }
 
@@ -100,21 +113,17 @@ resolve_target() {
 }
 
 ensure_bootstrap_deps() {
-  case "$os_name" in
-    Linux)
+  case "$pkg_manager" in
+    apt)
       if ! have_cmd git; then
         install_with_apt git
       fi
       ;;
-    Darwin)
+    brew)
       install_homebrew_if_needed
       if ! have_user_cmd git; then
         install_with_brew git
       fi
-      ;;
-    *)
-      echo "Unsupported OS: $os_name" >&2
-      exit 1
       ;;
   esac
 }
@@ -126,32 +135,28 @@ ensure_checkout_present() {
 }
 
 ensure_packages() {
-  local name linux_check_cmd darwin_check_cmd apt_packages brew_packages package_spec
+  local name apt_check_cmd brew_check_cmd apt_packages brew_packages
   local -a package_args
 
-  while IFS='|' read -r name linux_check_cmd darwin_check_cmd apt_packages brew_packages; do
+  while IFS='|' read -r name apt_check_cmd brew_check_cmd apt_packages brew_packages; do
     if [ -z "$name" ] || [[ "$name" == \#* ]]; then
       continue
     fi
 
-    if managed_cmd_exists "$linux_check_cmd" "$darwin_check_cmd"; then
+    if managed_cmd_exists "$apt_check_cmd" "$brew_check_cmd"; then
       continue
     fi
 
-    package_spec=$(package_spec_for_current_os "$apt_packages" "$brew_packages")
-    if [ -z "$package_spec" ]; then
-      echo "Skipping $name on $os_name: no package mapping" >&2
+    pkg=$(package_spec "$apt_packages" "$brew_packages")
+    if [ -z "$pkg" ]; then
+      echo "Skipping $name on $os_name ($pkg_manager): no package mapping" >&2
       continue
     fi
 
-    read -r -a package_args <<<"$package_spec"
-    case "$os_name" in
-      Linux)
-        install_with_apt "${package_args[@]}" </dev/null
-        ;;
-      Darwin)
-        install_with_brew "${package_args[@]}" </dev/null
-        ;;
+    read -r -a package_args <<<"$pkg"
+    case "$pkg_manager" in
+      apt)  install_with_apt  "${package_args[@]}" </dev/null ;;
+      brew) install_with_brew "${package_args[@]}" </dev/null ;;
     esac
   done < "$package_manifest"
 }
@@ -177,6 +182,7 @@ run_stow() {
 main() {
   require_sudo_context
   resolve_os
+  resolve_pkg_manager
   resolve_script_dir
   resolve_target
   ensure_bootstrap_deps

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -192,7 +192,10 @@ ensure_ssh_key() {
 
 run_stow() {
   cd "$target"
-  run_as_user ./stow.sh
+  case "$pkg_manager" in
+    brew) run_as_user env PATH="$brew_path" ./stow.sh ;;
+    *)    run_as_user ./stow.sh ;;
+  esac
 }
 
 main() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,9 +17,12 @@ run_as_user() {
   sudo -Hu "$SUDO_USER" -- "$@"
 }
 
+# Explicit PATH for brew commands. Needed because brew installs to
+# user-local prefixes that aren't in root's PATH.
 brew_path="/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 have_user_cmd() {
+  # sh -lc '...' sh "$1" — the extra "sh" sets $0 so $1 is the argument.
   run_as_user env PATH="$brew_path" \
     sh -lc 'command -v "$1" >/dev/null 2>&1' sh "$1"
 }
@@ -79,6 +82,7 @@ resolve_os() {
 }
 
 resolve_pkg_manager() {
+  # Non-apt Linux (e.g. Amazon Linux) uses Homebrew, same as macOS.
   case "$os_name" in
     Darwin)
       pkg_manager="brew"
@@ -126,6 +130,8 @@ package_spec() {
   esac
 }
 
+# Must be run via sudo so we can install system packages as root
+# while using SUDO_USER to run user-level commands (brew, stow, etc.).
 require_sudo_context() {
   if [ -z "${SUDO_USER:-}" ]; then
     echo "bootstrap.sh must be run via sudo so SUDO_USER is available" >&2
@@ -164,6 +170,7 @@ ensure_packages() {
   local name apt_check_cmd brew_check_cmd apt_packages brew_packages
   local -a package_args
 
+  # Fields: name|apt_check_cmd|brew_check_cmd|apt_packages|brew_packages
   while IFS='|' read -r name apt_check_cmd brew_check_cmd apt_packages brew_packages; do
     if [ -z "$name" ] || [[ "$name" == \#* ]]; then
       continue

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -56,9 +56,18 @@ install_with_system_pm() {
 install_homebrew_if_needed() {
   if ! have_user_cmd brew; then
     # Homebrew on Linux requires a C toolchain and a handful of utilities.
-    # Install them via the system package manager before handing off.
+    # Only install what's missing to avoid conflicts (e.g. curl vs
+    # curl-minimal on Amazon Linux).
     if [ "$os_name" = "Linux" ]; then
-      install_with_system_pm curl file gcc gcc-c++ make procps-ng
+      local needed=()
+      have_cmd curl  || needed+=(curl)
+      have_cmd file  || needed+=(file)
+      have_cmd gcc   || needed+=(gcc gcc-c++)
+      have_cmd make  || needed+=(make)
+      have_cmd ps    || needed+=(procps-ng)
+      if [ ${#needed[@]} -gt 0 ]; then
+        install_with_system_pm "${needed[@]}"
+      fi
     fi
     run_as_user env NONINTERACTIVE=1 /bin/bash -c \
       "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 apt_updated=0
 package_manifest=
+pkg_manager=
 script_dir=
 target=
 user_home=
@@ -16,13 +17,15 @@ run_as_user() {
   sudo -Hu "$SUDO_USER" -- "$@"
 }
 
+brew_path="/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
 have_user_cmd() {
-  run_as_user env PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+  run_as_user env PATH="$brew_path" \
     sh -lc 'command -v "$1" >/dev/null 2>&1' sh "$1"
 }
 
 brew_as_user() {
-  run_as_user env PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" brew "$@"
+  run_as_user env PATH="$brew_path" brew "$@"
 }
 
 install_with_apt() {
@@ -38,14 +41,50 @@ install_with_brew() {
   brew_as_user install "$@"
 }
 
+# Install a package using whatever system package manager is available.
+# Used only for pre-brew bootstrap prerequisites (e.g. curl).
+install_with_system_pm() {
+  if have_cmd apt-get; then
+    install_with_apt "$@"
+  elif have_cmd dnf; then
+    dnf install -y "$@"
+  elif have_cmd yum; then
+    yum install -y "$@"
+  fi
+}
+
 install_homebrew_if_needed() {
   if ! have_user_cmd brew; then
-    run_as_user /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    # Homebrew's installer requires curl.
+    if ! have_cmd curl; then
+      install_with_system_pm curl
+    fi
+    run_as_user env NONINTERACTIVE=1 /bin/bash -c \
+      "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 }
 
 resolve_os() {
   os_name="$(uname -s)"
+}
+
+resolve_pkg_manager() {
+  case "$os_name" in
+    Darwin)
+      pkg_manager="brew"
+      ;;
+    Linux)
+      if have_cmd apt-get; then
+        pkg_manager="apt"
+      else
+        pkg_manager="brew"
+      fi
+      ;;
+    *)
+      echo "Unsupported OS: $os_name" >&2
+      exit 1
+      ;;
+  esac
 }
 
 resolve_script_dir() {
@@ -54,36 +93,26 @@ resolve_script_dir() {
 }
 
 managed_cmd_exists() {
-  local linux_check_cmd="$1"
-  local darwin_check_cmd="$2"
+  local apt_check_cmd="$1"
+  local brew_check_cmd="$2"
 
-  case "$os_name" in
-    Linux)
-      [ -n "$linux_check_cmd" ] && have_cmd "$linux_check_cmd"
+  case "$pkg_manager" in
+    apt)
+      [ -n "$apt_check_cmd" ] && have_cmd "$apt_check_cmd"
       ;;
-    Darwin)
-      [ -n "$darwin_check_cmd" ] && have_user_cmd "$darwin_check_cmd"
-      ;;
-    *)
-      return 1
+    brew)
+      [ -n "$brew_check_cmd" ] && have_user_cmd "$brew_check_cmd"
       ;;
   esac
 }
 
-package_spec_for_current_os() {
+package_spec() {
   local apt_packages="$1"
   local brew_packages="$2"
 
-  case "$os_name" in
-    Linux)
-      printf '%s\n' "$apt_packages"
-      ;;
-    Darwin)
-      printf '%s\n' "$brew_packages"
-      ;;
-    *)
-      return 1
-      ;;
+  case "$pkg_manager" in
+    apt)  printf '%s\n' "$apt_packages" ;;
+    brew) printf '%s\n' "$brew_packages" ;;
   esac
 }
 
@@ -100,21 +129,17 @@ resolve_target() {
 }
 
 ensure_bootstrap_deps() {
-  case "$os_name" in
-    Linux)
+  case "$pkg_manager" in
+    apt)
       if ! have_cmd git; then
         install_with_apt git
       fi
       ;;
-    Darwin)
+    brew)
       install_homebrew_if_needed
       if ! have_user_cmd git; then
         install_with_brew git
       fi
-      ;;
-    *)
-      echo "Unsupported OS: $os_name" >&2
-      exit 1
       ;;
   esac
 }
@@ -126,32 +151,28 @@ ensure_checkout_present() {
 }
 
 ensure_packages() {
-  local name linux_check_cmd darwin_check_cmd apt_packages brew_packages package_spec
+  local name apt_check_cmd brew_check_cmd apt_packages brew_packages
   local -a package_args
 
-  while IFS='|' read -r name linux_check_cmd darwin_check_cmd apt_packages brew_packages; do
+  while IFS='|' read -r name apt_check_cmd brew_check_cmd apt_packages brew_packages; do
     if [ -z "$name" ] || [[ "$name" == \#* ]]; then
       continue
     fi
 
-    if managed_cmd_exists "$linux_check_cmd" "$darwin_check_cmd"; then
+    if managed_cmd_exists "$apt_check_cmd" "$brew_check_cmd"; then
       continue
     fi
 
-    package_spec=$(package_spec_for_current_os "$apt_packages" "$brew_packages")
-    if [ -z "$package_spec" ]; then
-      echo "Skipping $name on $os_name: no package mapping" >&2
+    pkg=$(package_spec "$apt_packages" "$brew_packages")
+    if [ -z "$pkg" ]; then
+      echo "Skipping $name on $os_name ($pkg_manager): no package mapping" >&2
       continue
     fi
 
-    read -r -a package_args <<<"$package_spec"
-    case "$os_name" in
-      Linux)
-        install_with_apt "${package_args[@]}" </dev/null
-        ;;
-      Darwin)
-        install_with_brew "${package_args[@]}" </dev/null
-        ;;
+    read -r -a package_args <<<"$pkg"
+    case "$pkg_manager" in
+      apt)  install_with_apt  "${package_args[@]}" </dev/null ;;
+      brew) install_with_brew "${package_args[@]}" </dev/null ;;
     esac
   done < "$package_manifest"
 }
@@ -177,6 +198,7 @@ run_stow() {
 main() {
   require_sudo_context
   resolve_os
+  resolve_pkg_manager
   resolve_script_dir
   resolve_target
   ensure_bootstrap_deps

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -55,9 +55,10 @@ install_with_system_pm() {
 
 install_homebrew_if_needed() {
   if ! have_user_cmd brew; then
-    # Homebrew's installer requires curl.
-    if ! have_cmd curl; then
-      install_with_system_pm curl
+    # Homebrew on Linux requires a C toolchain and a handful of utilities.
+    # Install them via the system package manager before handing off.
+    if [ "$os_name" = "Linux" ]; then
+      install_with_system_pm curl file gcc gcc-c++ make procps-ng
     fi
     run_as_user env NONINTERACTIVE=1 /bin/bash -c \
       "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/packages.tsv
+++ b/packages.tsv
@@ -1,4 +1,4 @@
-# name|linux_check_cmd|darwin_check_cmd|apt_packages|brew_packages
+# name|apt_check_cmd|brew_check_cmd|apt_packages|brew_packages
 apt-file|apt-file||apt-file|
 binutils|strings|strings|binutils|binutils
 black|black|black|black|black

--- a/stow.sh
+++ b/stow.sh
@@ -6,6 +6,11 @@ if ! command -v "$stow_bin" >/dev/null 2>&1; then
   stow_bin=stow
 fi
 
+if ! command -v "$stow_bin" >/dev/null 2>&1; then
+  echo "error: neither xstow nor stow found" >&2
+  exit 1
+fi
+
 for f in git emacs zsh ssh sqlite screen ispell
 do
   if ! "$stow_bin" "$f"; then

--- a/stow.sh
+++ b/stow.sh
@@ -6,14 +6,19 @@ if ! command -v "$stow_bin" >/dev/null 2>&1; then
   stow_bin=stow
 fi
 
-if ! command -v "$stow_bin" >/dev/null 2>&1; then
-  echo "error: neither xstow nor stow found" >&2
-  exit 1
-fi
-
+failed=0
 for f in git emacs zsh ssh sqlite screen ispell
 do
-  if ! "$stow_bin" "$f"; then
-    echo "warning: failed to stow $f; continuing" >&2
-  fi
+  output=$("$stow_bin" "$f" 2>&1) || {
+    # Conflicts with existing non-link targets are expected in CI
+    # where tools like git create default configs before stow runs.
+    if echo "$output" | grep -q "since neither a link nor a directory"; then
+      echo "warning: stow $f skipped (existing target conflict)" >&2
+    else
+      echo "error: failed to stow $f:" >&2
+      echo "$output" >&2
+      failed=1
+    fi
+  }
 done
+exit "$failed"


### PR DESCRIPTION
Add Amazon Linux 2023 to the bootstrap CI matrix and make `bootstrap.sh` work on non-apt Linux by using Homebrew — the same approach macOS already takes.

## Changes

### Workflow (`.github/workflows/bootstrap.yml`)
- Add `bootstrap-amazon-linux` job running in an `amazonlinux:2023` container
- Manual clone/checkout instead of `actions/checkout` (stock AL2023 lacks `tar`)
- **TODO (needs `workflow` OAuth scope):** golf `dnf install` down to `git gzip shadow-utils sudo tar` and drop `"Development Tools"` — bootstrap.sh already installs its own Homebrew prerequisites

### bootstrap.sh
- Add `resolve_pkg_manager()`: picks `apt` when `apt-get` exists, `brew` otherwise
- All package operations branch on `pkg_manager` instead of `os_name`
- `install_homebrew_if_needed` installs only *missing* prerequisites to avoid package conflicts (e.g. `curl` vs `curl-minimal` on AL2023)
- Include Linuxbrew path (`/home/linuxbrew/.linuxbrew/bin`) in brew helpers
- `run_stow` passes the brew PATH so brew-installed `stow` is found

### stow.sh
- Whitelist only the specific "existing target" conflict (expected in CI when tools create default configs before stow runs)
- All other errors — including `command not found` — now fail the script

### packages.tsv
- Header renamed to `apt_check_cmd`/`brew_check_cmd` for clarity
