### PR TITLE
Disable feedback survey in Claude Code settings

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,4 +1,7 @@
 {
   "model": "opus",
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "env": {
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1"
+  }
 }


### PR DESCRIPTION
## Summary
- Set `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY=1` as an environment variable in Claude `settings.json`

## Test plan
- [ ] Verify Claude Code no longer prompts with feedback surveys

🤖 Generated with [Claude Code](https://claude.com/claude-code)