### PR TITLE
Update Claude Code configuration with workflow preferences

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -2,8 +2,25 @@
 
 ## Git
 - Always use SSH URLs for GitHub remotes (`git@github.com:...`), never HTTPS.
+- Never rewrite git history in a way that requires force-pushing (no `--amend`, `rebase`, etc. on pushed commits). PRs are squash-merged, so branch history doesn't matter.
+- When a feature branch is behind main, prefer merging main into the feature branch over rebasing.
 
 ## GitHub Repo Setup
 - Squash merge only (disable merge commits and rebase merges).
 - Branch protection (require PRs, no direct pushes, enforce for admins) — only set up on public repos. Skip for private repos (requires Pro).
 - Keep repos private unless told otherwise.
+
+## PR Review Comments
+- When fixing inline comments on PRs, reply to the comment explaining what was changed, then resolve the comment thread when appropriate.
+- Reply to a review comment via REST: `gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments/COMMENT_ID/replies -X POST -f body="..."`. The PR number is required in the path.
+- To resolve threads, use the GraphQL `resolveReviewThread` mutation. The `threadId` must be a `PRRT_...` (review thread ID), NOT a `PRRC_...` (review comment ID). Fetch thread IDs first via: `gh api graphql -f query='{ repository(owner:"O",name:"R") { pullRequest(number:N) { reviewThreads(first:50) { nodes { id comments(first:1) { nodes { body } } } } } } }'`
+
+## Testing
+- Prefer red-green TDD where it makes sense (write a failing test first, then make it pass, then refactor).
+- In tests, prefer verbosity over conciseness when it makes the test more readable (e.g. inline data construction instead of helpers).
+
+## Session
+- When the user does `/rename`, also run `tmux rename-session "<new name>"` to keep the tmux session name in sync.
+- When opening or starting work on a PR, check if the current Claude session name already contains a PR link. If not, append the PR URL to the current session name: run `tmux rename-session "<current name> <pr-url>"` yourself, and print a pasteable `/rename <current name> <pr-url>` for the user to run (Claude cannot invoke `/rename` directly).
+- "Current name" means the Claude session name (shown in the session-rename system reminder), not the worktree branch or any auto-generated identifier.
+- To find the current session name: read `~/.claude/sessions/*.json`, match on `cwd` matching the current working directory (or parent), and extract the `name` field. Example: `jq -r 'select(.cwd == "<cwd>") | .name' ~/.claude/sessions/*.json`.

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,8 +1,18 @@
 {
+  "env": {
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git push:*)"
+    ],
+    "defaultMode": "acceptEdits"
+  },
   "model": "us.anthropic.claude-opus-4-6-v1",
   "effortLevel": "high",
   "skipDangerousModePermissionPrompt": true,
-  "env": {
-    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1"
+  "theme": "light",
+  "enabledPlugins": {
+    "rust-analyzer-lsp@claude-plugins-official": true
   }
 }

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,4 +1,5 @@
 {
-  "model": "opus",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "effortLevel": "high",
   "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added sections for git workflow preferences (no force-pushing, merge over rebase), PR review comment handling (REST replies, GraphQL thread resolution), testing preferences (red-green TDD, verbose tests), and session management (tmux rename-session sync, PR link tracking in session name).
- **settings.json**: Added `git push` permission, `acceptEdits` default mode, light theme, and rust-analyzer LSP plugin. Reorganized existing settings (moved `env` block to top).

## Test plan
- [ ] Verify `claude/.claude/CLAUDE.md` renders correctly and all sections are present
- [ ] Verify `claude/.claude/settings.json` is valid JSON with correct keys
- [ ] Confirm Claude Code picks up the new settings after stowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)