### PR TITLE
Add codex stow package with CLAUDE.md fallback

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,4 +1,5 @@
 {
-  "model": "opus",
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "effortLevel": "high",
   "skipDangerousModePermissionPrompt": true
 }

--- a/codex/.codex/config.toml
+++ b/codex/.codex/config.toml
@@ -1,0 +1,22 @@
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+service_tier = "fast"
+project_doc_fallback_filenames = ["CLAUDE.md"]
+
+[projects."/local/home/frederrx"]
+trust_level = "trusted"
+
+[projects."/local/home/frederrx/slime"]
+trust_level = "trusted"
+
+[projects."/local/home/frederrx/ci_cdk/src/AGIAutonomyArtifactsCDK"]
+trust_level = "trusted"
+
+[projects."/local/home/frederrx/dotfiles"]
+trust_level = "trusted"
+
+[tui.model_availability_nux]
+"gpt-5.5" = 4
+
+[notice]
+fast_default_opt_out = true

--- a/codex/.codex/config.toml
+++ b/codex/.codex/config.toml
@@ -3,18 +3,6 @@ model_reasoning_effort = "xhigh"
 service_tier = "fast"
 project_doc_fallback_filenames = ["CLAUDE.md"]
 
-[projects."/local/home/frederrx"]
-trust_level = "trusted"
-
-[projects."/local/home/frederrx/slime"]
-trust_level = "trusted"
-
-[projects."/local/home/frederrx/ci_cdk/src/AGIAutonomyArtifactsCDK"]
-trust_level = "trusted"
-
-[projects."/local/home/frederrx/dotfiles"]
-trust_level = "trusted"
-
 [tui.model_availability_nux]
 "gpt-5.5" = 4
 

--- a/stow.sh
+++ b/stow.sh
@@ -7,7 +7,7 @@ if ! command -v "$stow_bin" >/dev/null 2>&1; then
 fi
 
 failed=0
-for f in git emacs zsh ssh sqlite screen ispell claude
+for f in git emacs zsh ssh sqlite screen ispell claude codex
 do
   output=$("$stow_bin" "$f" 2>&1) || {
     # Conflicts with existing non-link targets are expected in CI


### PR DESCRIPTION
## Summary
- Adds a `codex/` stow package that manages `~/.codex/config.toml`
- Configures `project_doc_fallback_filenames = ["CLAUDE.md"]` so Codex reads CLAUDE.md files
- Adds `codex` to the stow loop in `stow.sh`

## Test plan
- [x] Verified symlink: `~/.codex/config.toml` → `../dotfiles/codex/.codex/config.toml`
- [ ] Run `./stow.sh` on a clean checkout to confirm no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)