### PR TITLE
Add TOML package manifest with generator and sync CI

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -11,6 +11,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  packages-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check packages.tsv is in sync with packages.toml
+        run: |
+          python3 generate_packages.py > /tmp/packages_generated.tsv
+          diff packages.tsv /tmp/packages_generated.tsv
+
   bootstrap:
     strategy:
       matrix:

--- a/generate_packages.py
+++ b/generate_packages.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate packages.tsv from packages.toml.
+
+Run after editing packages.toml:
+    python3 generate_packages.py > packages.tsv
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ImportError:
+        sys.exit("Python 3.11+ or 'pip install tomli' required")
+
+HEADER = "# name|apt_check_cmd|brew_check_cmd|apt_packages|brew_packages"
+
+
+def resolve(name: str, spec: dict) -> tuple[str, str, str, str, str]:
+    default_cmd = spec.get("cmd", name)
+
+    apt = spec.get("apt", name)
+    brew = spec.get("brew", name)
+
+    if apt is False:
+        apt_cmd = ""
+        apt_pkg = ""
+    else:
+        apt_cmd = spec.get("apt_cmd", default_cmd)
+        apt_pkg = " ".join(apt) if isinstance(apt, list) else apt
+
+    if brew is False:
+        brew_cmd = ""
+        brew_pkg = ""
+    else:
+        brew_cmd = spec.get("brew_cmd", default_cmd)
+        brew_pkg = brew
+
+    return name, apt_cmd, brew_cmd, apt_pkg, brew_pkg
+
+
+def main() -> None:
+    toml_path = Path(__file__).parent / "packages.toml"
+    with open(toml_path, "rb") as f:
+        data = tomllib.load(f)
+
+    rows = sorted(
+        (resolve(name, spec) for name, spec in data.items()),
+        key=lambda r: r[0],
+    )
+
+    print(HEADER)
+    for row in rows:
+        print("|".join(row))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages.toml
+++ b/packages.toml
@@ -1,0 +1,72 @@
+# Package manifest. Fields default to the table name if omitted.
+#
+# cmd      = command to check on both platforms (default: name)
+# apt_cmd  = command to check on apt systems (default: cmd)
+# brew_cmd = command to check on brew systems (default: cmd)
+# apt      = apt package(s) to install — string or list (default: name, false = skip)
+# brew     = brew package to install (default: name, false = skip)
+
+[apt-file]
+brew = false
+
+[binutils]
+cmd = "strings"
+
+[black]
+
+[colordiff]
+
+[dig]
+apt = "dnsutils"
+brew = "bind"
+
+[emacs]
+apt = "emacs-nox"
+
+[figlet]
+
+[fzf]
+
+[ghostscript]
+cmd = "gs"
+
+[git]
+
+[graphviz]
+cmd = "dot"
+
+[htop]
+
+[ispell]
+brew = false
+
+[jq]
+
+[kpcli]
+brew = false
+
+[make]
+
+[nano]
+
+[pip3]
+apt = ["python3-pip", "python3-venv"]
+brew = "python"
+
+[python3]
+apt = ["python3-pip", "python3-venv"]
+brew = "python"
+
+[rg]
+apt = "ripgrep"
+brew = "ripgrep"
+
+[screen]
+
+[stow]
+apt = "xstow"
+apt_cmd = "xstow"
+
+[tree]
+
+[zsh]

--- a/packages.tsv
+++ b/packages.tsv
@@ -7,9 +7,9 @@ dig|dig|dig|dnsutils|bind
 emacs|emacs|emacs|emacs-nox|emacs
 figlet|figlet|figlet|figlet|figlet
 fzf|fzf|fzf|fzf|fzf
+ghostscript|gs|gs|ghostscript|ghostscript
 git|git|git|git|git
 graphviz|dot|dot|graphviz|graphviz
-ghostscript|gs|gs|ghostscript|ghostscript
 htop|htop|htop|htop|htop
 ispell|ispell||ispell|
 jq|jq|jq|jq|jq


### PR DESCRIPTION
## Summary

- Replaces the hand-edited `packages.tsv` with a `packages.toml` source of truth
- Smart defaults: bare `[name]` entry means the name is used as the check command, apt package, and brew package — only specify what differs
- `generate_packages.py` renders the TOML to TSV (sorted alphabetically)
- New `packages-sync` CI job fails if `packages.tsv` diverges from what the generator would produce

## TOML format

```toml
[fzf]               # everything defaults to "fzf"

[dig]               # package names differ per platform
apt = "dnsutils"
brew = "bind"

[binutils]          # check command differs from package name
cmd = "strings"

[stow]              # apt uses a different name entirely
apt = "xstow"
apt_cmd = "xstow"

[python3]           # multiple apt packages
apt = ["python3-pip", "python3-venv"]
brew = "python"

[apt-file]          # apt-only
brew = false
```

## Test plan

- [ ] `packages-sync` CI job passes
- [ ] Bootstrap CI jobs still pass (packages.tsv content is unchanged except ghostscript/graphviz alphabetical reorder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)