### PR TITLE
Add Codex fork skill

### DIFF
--- a/codex/.codex/skills/fork/SKILL.md
+++ b/codex/.codex/skills/fork/SKILL.md
@@ -19,7 +19,7 @@ By default, the script:
 2. Creates a new branch at that commit.
 3. Adds a new worktree for that branch.
 4. Starts a detached tmux session with its working directory set to the worktree.
-5. Runs `codex fork --last --all -C <worktree>` inside tmux.
+5. Runs `codex fork --yolo --last --all -C <worktree>` inside tmux.
 
 Report the resulting worktree path, branch name, tmux session name, and attach command to the user.
 
@@ -27,7 +27,7 @@ Report the resulting worktree path, branch name, tmux session name, and attach c
 
 Run from the repository or worktree the user wants to fork. If the user gives a task name, pass it with `--name`; otherwise let the script generate a timestamped name.
 
-Prefer the default `codex fork --last --all` behavior when the user says to fork "this" or "the current" session. `--all` avoids cwd filtering after switching into the new worktree. Pass `--session-id <uuid>` only when the user gives a specific Codex session id.
+Prefer the default `codex fork --yolo --last --all` behavior when the user says to fork "this" or "the current" session. `--all` avoids cwd filtering after switching into the new worktree. Pass `--session-id <uuid>` only when the user gives a specific Codex session id.
 
 Use `--branch <branch-name>` when the user requests an exact branch name. Use `--path <worktree-path>` when the user requests an exact worktree location.
 

--- a/codex/.codex/skills/fork/SKILL.md
+++ b/codex/.codex/skills/fork/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: fork
+description: "Create an isolated Git worktree from the current repository state, check out a new branch at the current HEAD, start a tmux session in that worktree, and launch a forked Codex session there. Use when the user asks to fork the current Codex work, split off a parallel task, create a new worktree/branch/tmux Codex session, or continue the current context in an isolated workspace."
+---
+
+# Fork
+
+## Quick Start
+
+Use `scripts/fork_worktree.py` from the skill directory to create the workspace and launch Codex:
+
+```bash
+python3 ~/.codex/skills/fork/scripts/fork_worktree.py --name <short-task-name>
+```
+
+By default, the script:
+
+1. Resolves the current Git repository and current `HEAD`.
+2. Creates a new branch at that commit.
+3. Adds a new worktree for that branch.
+4. Starts a detached tmux session with its working directory set to the worktree.
+5. Runs `codex fork --last --all -C <worktree>` inside tmux.
+
+Report the resulting worktree path, branch name, tmux session name, and attach command to the user.
+
+## Workflow
+
+Run from the repository or worktree the user wants to fork. If the user gives a task name, pass it with `--name`; otherwise let the script generate a timestamped name.
+
+Prefer the default `codex fork --last --all` behavior when the user says to fork "this" or "the current" session. `--all` avoids cwd filtering after switching into the new worktree. Pass `--session-id <uuid>` only when the user gives a specific Codex session id.
+
+Use `--branch <branch-name>` when the user requests an exact branch name. Use `--path <worktree-path>` when the user requests an exact worktree location.
+
+If the source worktree has uncommitted changes, stop and ask whether to commit, stash, or continue from committed `HEAD` only. To continue from `HEAD` while leaving source changes behind, rerun with `--allow-dirty-source`.
+
+## Examples
+
+Create a named fork:
+
+```bash
+python3 ~/.codex/skills/fork/scripts/fork_worktree.py --name fix-login-tests
+```
+
+Create a fork with an exact branch and worktree path:
+
+```bash
+python3 ~/.codex/skills/fork/scripts/fork_worktree.py --branch codex/fix-login-tests --path ../repo-fix-login-tests
+```
+
+Fork a specific Codex session id:
+
+```bash
+python3 ~/.codex/skills/fork/scripts/fork_worktree.py --name api-refactor --session-id 00000000-0000-0000-0000-000000000000
+```
+
+Preview without making changes:
+
+```bash
+python3 ~/.codex/skills/fork/scripts/fork_worktree.py --name dry-run-example --dry-run
+```

--- a/codex/.codex/skills/fork/agents/openai.yaml
+++ b/codex/.codex/skills/fork/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fork"
+  short_description: "Fork worktree, branch, tmux, and Codex"
+  default_prompt: "Use $fork to create a new worktree, branch, tmux session, and forked Codex session for this task."

--- a/codex/.codex/skills/fork/scripts/fork_worktree.py
+++ b/codex/.codex/skills/fork/scripts/fork_worktree.py
@@ -200,7 +200,7 @@ def create_worktree(config: ForkConfig, cwd: Path) -> None:
 
 
 def start_tmux(config: ForkConfig) -> list[str]:
-    codex_command = ["codex", "fork"]
+    codex_command = ["codex", "fork", "--yolo"]
     if config.session_id:
         codex_command.extend(["-C", str(config.worktree_path), config.session_id])
     else:

--- a/codex/.codex/skills/fork/scripts/fork_worktree.py
+++ b/codex/.codex/skills/fork/scripts/fork_worktree.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Create a Git worktree, start tmux there, and launch a forked Codex session."""
+
+import argparse
+import datetime
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ForkConfig:
+    name: str
+    branch: str
+    worktree_path: Path
+    tmux_session: str
+    base_ref: str
+    session_id: str | None
+    allow_dirty_source: bool
+    dry_run: bool
+
+
+def run_git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def require_command(command: str) -> None:
+    if shutil.which(command) is None:
+        raise RuntimeError(f"Required command not found on PATH: {command}")
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip().lower())
+    slug = re.sub(r"-+", "-", slug).strip("-._")
+    if not slug:
+        raise RuntimeError("Name must contain at least one letter or digit")
+    return slug[:64]
+
+
+def tmux_safe_name(value: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9_-]+", "-", value)
+    name = re.sub(r"-+", "-", name).strip("-_")
+    if not name:
+        raise RuntimeError("tmux session name must contain at least one letter or digit")
+    return name[:80]
+
+
+def generated_name(head: str) -> str:
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d-%H%M%S")
+    return f"codex-{timestamp}-{head[:8]}"
+
+
+def default_worktree_parent(repo_root: Path) -> Path:
+    parts = repo_root.parts
+    for index in range(len(parts) - 2):
+        if parts[index] == ".claude" and parts[index + 1] == "worktrees":
+            return Path(*parts[: index + 2])
+
+    claude_worktrees = repo_root / ".claude" / "worktrees"
+    if claude_worktrees.exists():
+        return claude_worktrees
+
+    dot_worktrees = repo_root / ".worktrees"
+    if dot_worktrees.exists():
+        return dot_worktrees
+
+    return repo_root.parent / f"{repo_root.name}-worktrees"
+
+
+def unique_branch(base_branch: str, cwd: Path) -> str:
+    existing = set(run_git(["for-each-ref", "--format=%(refname:short)", "refs/heads"], cwd).splitlines())
+    if base_branch not in existing:
+        return base_branch
+    for suffix in range(2, 1000):
+        candidate = f"{base_branch}-{suffix}"
+        if candidate not in existing:
+            return candidate
+    raise RuntimeError(f"Could not find an unused branch name based on {base_branch}")
+
+
+def unique_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+    for suffix in range(2, 1000):
+        candidate = path.with_name(f"{path.name}-{suffix}")
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError(f"Could not find an unused worktree path based on {path}")
+
+
+def unique_tmux_session(base_session: str) -> str:
+    result = subprocess.run(
+        ["tmux", "list-sessions", "-F", "#{session_name}"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    existing = set(result.stdout.splitlines()) if result.returncode == 0 else set()
+    if base_session not in existing:
+        return base_session
+    for suffix in range(2, 1000):
+        candidate = f"{base_session}-{suffix}"
+        if candidate not in existing:
+            return candidate
+    raise RuntimeError(f"Could not find an unused tmux session name based on {base_session}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a Git worktree, new branch, tmux session, and forked Codex session."
+    )
+    parser.add_argument("--name", help="Short task name used for generated branch, path, and tmux names.")
+    parser.add_argument("--branch", help="Exact branch name to create. Fails if it already exists.")
+    parser.add_argument("--path", type=Path, help="Exact worktree path to create.")
+    parser.add_argument("--tmux-session", help="Exact tmux session name. Fails if it already exists.")
+    parser.add_argument("--session-id", help="Specific Codex session UUID to fork. Defaults to codex fork --last.")
+    parser.add_argument(
+        "--allow-dirty-source",
+        action="store_true",
+        help="Allow forking from committed HEAD even when the source worktree has uncommitted changes.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print planned actions without changing anything.")
+    return parser.parse_args()
+
+
+def build_config(args: argparse.Namespace, cwd: Path) -> ForkConfig:
+    require_command("git")
+    require_command("tmux")
+    require_command("codex")
+
+    repo_root = Path(run_git(["rev-parse", "--show-toplevel"], cwd)).resolve()
+    head = run_git(["rev-parse", "HEAD"], repo_root)
+    name = slugify(args.name) if args.name else generated_name(head)
+
+    if args.branch:
+        branch = args.branch
+    else:
+        branch = unique_branch(f"codex/{name}", repo_root)
+
+    if args.path:
+        worktree_path = args.path.expanduser().resolve()
+    else:
+        worktree_path = unique_path(default_worktree_parent(repo_root) / name)
+
+    if args.tmux_session:
+        tmux_session = args.tmux_session
+    else:
+        tmux_session = unique_tmux_session(f"codex-{tmux_safe_name(name)}")
+
+    return ForkConfig(
+        name=name,
+        branch=branch,
+        worktree_path=worktree_path,
+        tmux_session=tmux_session,
+        base_ref=head,
+        session_id=args.session_id,
+        allow_dirty_source=args.allow_dirty_source,
+        dry_run=args.dry_run,
+    )
+
+
+def check_source_clean(cwd: Path, allow_dirty_source: bool) -> None:
+    status = run_git(["status", "--porcelain=v1"], cwd)
+    if status and not allow_dirty_source:
+        raise RuntimeError(
+            "Source worktree has uncommitted changes. Commit or stash them, or rerun with "
+            "--allow-dirty-source to fork from committed HEAD only."
+        )
+
+
+def create_worktree(config: ForkConfig, cwd: Path) -> None:
+    if config.dry_run:
+        return
+
+    if config.branch in run_git(["for-each-ref", "--format=%(refname:short)", "refs/heads"], cwd).splitlines():
+        raise RuntimeError(f"Branch already exists: {config.branch}")
+    if config.worktree_path.exists():
+        raise RuntimeError(f"Worktree path already exists: {config.worktree_path}")
+
+    config.worktree_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "worktree", "add", "-b", config.branch, str(config.worktree_path), config.base_ref],
+        cwd=cwd,
+        check=True,
+    )
+
+
+def start_tmux(config: ForkConfig) -> list[str]:
+    codex_command = ["codex", "fork"]
+    if config.session_id:
+        codex_command.extend(["-C", str(config.worktree_path), config.session_id])
+    else:
+        codex_command.extend(["--last", "--all", "-C", str(config.worktree_path)])
+
+    shell_command = f"exec {shlex.join(codex_command)}"
+    tmux_command = [
+        "tmux",
+        "new-session",
+        "-d",
+        "-s",
+        config.tmux_session,
+        "-c",
+        str(config.worktree_path),
+        shell_command,
+    ]
+
+    if not config.dry_run:
+        subprocess.run(tmux_command, check=True)
+
+    return tmux_command
+
+
+def print_summary(config: ForkConfig, tmux_command: list[str]) -> None:
+    print(f"Name: {config.name}")
+    print(f"Branch: {config.branch}")
+    print(f"Base HEAD: {config.base_ref}")
+    print(f"Worktree: {config.worktree_path}")
+    print(f"tmux session: {config.tmux_session}")
+    print(f"tmux attach: tmux attach -t {shlex.quote(config.tmux_session)}")
+    print(f"tmux command: {shlex.join(tmux_command)}")
+    if config.dry_run:
+        print("Dry run: no changes made")
+
+
+def main() -> int:
+    args = parse_args()
+    cwd = Path.cwd()
+    try:
+        config = build_config(args, cwd)
+        check_source_clean(cwd, config.allow_dirty_source)
+        create_worktree(config, cwd)
+        tmux_command = start_tmux(config)
+        print_summary(config, tmux_command)
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the Codex fork skill under the codex stow package
- include the OpenAI skill metadata
- include the fork_worktree.py helper script for branch/worktree/tmux/Codex session setup

## Verification
- python3 -m py_compile codex/.codex/skills/fork/scripts/fork_worktree.py
- python3 codex/.codex/skills/fork/scripts/fork_worktree.py --name dry-run-check --dry-run --allow-dirty-source