### PR TITLE
[tmux] chore: add tmux resurrect autosave

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -5,3 +5,19 @@ set -g status-left '#[fg=colour231,bg=colour31,bold] #S #[default]'
 # Use a quieter dark bar so the session name stands out.
 set -g status-style 'bg=colour236,fg=colour250'
 set -g status-right-style 'fg=colour250,bg=colour236'
+
+# Persist tmux sessions and restore them after server or host restarts.
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @resurrect-dir '~/.tmux/resurrect'
+set -g @resurrect-save-command-strategy 'linux_procfs_or_self'
+set -g @resurrect-capture-pane-contents 'on'
+set -g @resurrect-processes '"~codex->codex *"'
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
+set -g @continuum-boot 'on'
+
+# Keep TPM last so tmux-continuum can prepend its autosave hook to status-right.
+# If anything overwrites status-right after TPM runs, continuum autosave stops.
+run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/save_command_strategies/linux_procfs_or_self.sh
+++ b/tmux/save_command_strategies/linux_procfs_or_self.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+PANE_PID="$1"
+
+if [ -z "$PANE_PID" ]; then
+	exit 0
+fi
+
+command_from_pid() {
+	local pid="$1"
+	if [ -r "/proc/${pid}/cmdline" ]; then
+		xargs -0 bash -c 'printf "%q " "$0" "$@"' < "/proc/${pid}/cmdline" | sed 's/[[:space:]]*$//'
+	fi
+}
+
+COMMAND_PID="$(pgrep -P "$PANE_PID" | head -n 1)"
+
+if [ -n "$COMMAND_PID" ]; then
+	command_from_pid "$COMMAND_PID"
+else
+	command_from_pid "$PANE_PID"
+fi


### PR DESCRIPTION
## Summary
- Add TPM-managed `tmux-resurrect` and `tmux-continuum` configuration for tmux layout persistence.
- Enable automatic restore on tmux startup, 15-minute autosaves, pane-content capture, and user-level tmux boot startup.
- Add a custom Linux procfs save strategy so panes that run `codex` directly are saved with their full command line, e.g. `codex --yolo resume <thread-id>`.

## Why
The default tmux-resurrect save strategy only captured `codex` for direct child panes. That recreates a pane, but it does not reliably reopen the same Codex conversation. The custom strategy falls back from child process command lookup to the pane process itself, so restored panes keep the resume command and working directory.

## Restore Path
After a tmux/server crash, start tmux and let continuum auto-restore. Manual fallback remains:

```bash
tmux new-session -d -s restore-bootstrap
~/.tmux/plugins/tmux-resurrect/scripts/restore.sh
```

## Verification
- Saved the current tmux layout with tmux-resurrect.
- Verified `~/.tmux/resurrect/last` records full `codex --yolo resume <thread-id>` commands.
- Killed the tmux server and confirmed the saved sessions restored, including session names and Codex commands.